### PR TITLE
Remove old dependencies definition

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,7 +7,6 @@ $EM_CONF[$_EXTKEY] = [
 	'author' => 'Mittwald CM Service',
 	'author_email' => 'support@mittwald.de',
 	'author_company' => 'Mittwald CM Service',
-	'dependencies' => 'cms,extbase,fluid,sr_feuser_register,static_info_tables',
 	'state' => 'stable',
 	'uploadfolder' => 0,
 	'createDirs' => 'typo3temp/typo3_forum,typo3temp/typo3_forum/gravatar, typo3temp/typo3_forum/workflowstatus',


### PR DESCRIPTION
The `dependencies` definition in `ext_emconf.php` using a comma
separated string is not used anymore since < TYPO3 6.2. Remove the
definition.

Fixes: https://github.com/mittwald/typo3_forum/issues/274