### PR TITLE
[BUGFIX] Display "readers" column only once in Topic-TCA

### DIFF
--- a/Configuration/TCA/tx_typo3forum_domain_model_forum_topic.php
+++ b/Configuration/TCA/tx_typo3forum_domain_model_forum_topic.php
@@ -21,7 +21,7 @@ return [
 			.',criteria_options,tags,subscribers,fav_subscribers,readers'
 	],
 	'types' => [
-		'0' => ['showitem' => 'hidden,type,subject,posts,author,last_post,forum,readers,question,solution,closed,sticky,criteria_options,tags,subscribers,fav_subscribers,readers'],
+		'0' => ['showitem' => 'hidden,type,subject,posts,author,last_post,forum,question,solution,closed,sticky,criteria_options,tags,subscribers,fav_subscribers,readers'],
 		'1' => ['showitem' => 'hidden,type,subject,forum,last_post,target'],
 	],
 	'columns' => [


### PR DESCRIPTION
The "readers" column of Topics was shown twice when opening the record
in the Backend-TCA. This patch removes one of the definitions.