### PR TITLE
[BUGFIX] Correctly display pagebrowser link to first page

### DIFF
--- a/Resources/Private/Templates/Bootstrap/ViewHelpers/Widget/Paginate/Index.html
+++ b/Resources/Private/Templates/Bootstrap/ViewHelpers/Widget/Paginate/Index.html
@@ -47,7 +47,7 @@
 										<f:widget.link arguments="{currentPage: page.number}" class="page-link">{page.number}</f:widget.link>
 									</f:then>
 									<f:else>
-										<f:widget.link>{page.number}</f:widget.link>
+										<f:widget.link class="page-link">{page.number}</f:widget.link>
 									</f:else>
 								</f:if>
 							</li>


### PR DESCRIPTION
In the Bootstrap template the CSS class "page-link" was missing on the
link to the first page (bug visible only after selecting another page).
This patch displays the link correctly in the same style as the others.