### PR TITLE
[BUGFIX] Sort topics of a forum in BE like in FE

### DIFF
--- a/Configuration/TCA/tx_typo3forum_domain_model_forum_forum.php
+++ b/Configuration/TCA/tx_typo3forum_domain_model_forum_forum.php
@@ -123,6 +123,7 @@ return [
 			'config' => [
 				'type' => 'inline',
 				'foreign_table' => 'tx_typo3forum_domain_model_forum_topic',
+				'foreign_default_sortby' => 'ORDER BY tx_typo3forum_domain_model_forum_topic.sticky DESC, tx_typo3forum_domain_model_forum_topic.last_post_crdate DESC',
 				'foreign_field' => 'forum',
 				'maxitems' => 999999,
 				'appearance' => [


### PR DESCRIPTION
Use the same sorting definition for topics in Backend when editing a
forum like in Frontend (sticky first, then by newest post)