### PR TITLE
[BUGFIX] Avoid SQL error in PostsWithoutAuthorNameUpdate on MySQL

### DIFF
--- a/Classes/Updates/PostsWithoutAuthorNameUpdate.php
+++ b/Classes/Updates/PostsWithoutAuthorNameUpdate.php
@@ -24,7 +24,6 @@
 
 namespace Mittwald\Typo3Forum\Updates;
 
-use PDO;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
@@ -144,7 +143,7 @@ class PostsWithoutAuthorNameUpdate extends AbstractUpdate {
 			)
 			->andWhere($queryBuilder->expr()->eq('author', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)))
 			->execute()
-			->fetch(PDO::FETCH_COLUMN);
+			->fetchColumn();
 
 		return (int)$numberOfPostsToUpdate > 0;
 	}


### PR DESCRIPTION
Avoid a `MysqliException` `Unknown fetch type '7'` when executing the
upgrade wizard `PostsWithoutAuthorNameUpdate` on MySQL by using the
`fetchColumn()` method instead of `fetch(PDO::FETCH_COLUMN)`.