### PR TITLE
[BUGFIX] Show "disable" option for fe_users in backend again

### DIFF
--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -9,10 +9,6 @@ $tempColumns = [
 		'exclude' => 1,
 		'config' => ['type' => 'passthrough'],
 	],
-	'disable' => [
-		'exclude' => 1,
-		'config' => ['type' => 'passthrough'],
-	],
 	'date_of_birth' => [
 		'exclude' => 1,
 		'config' => ['type' => 'passthrough'],


### PR DESCRIPTION
Commit d795a992 `[TASK] reports & mod function` in 07-2013 added a TCA
config overriding the `fe_users.disable` column type from `check` to
`passthrough` which hides the field in the backend making it impossible
to disable fe_users records there. This was probably not on purpose as
there are no negative side effects when editing the record in the
backend.

This patch removes the override in order to re-enable the functionality
to disable fe_users in the backend.