### PR TITLE
[BUGFIX] Add missing exclude definitions for fe_user columns

### DIFF
--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -18,6 +18,7 @@ $tempColumns = [
 		'config' => ['type' => 'passthrough'],
 	],
 	'tx_typo3forum_rank' => [
+		'exclude' => 1,
 		'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_user_rank',
 		'config' => [
 			'type' => 'select',
@@ -163,12 +164,14 @@ $tempColumns = [
 		],
 	],
 	'tx_typo3forum_use_gravatar' => [
+		'exclude' => 1,
 		'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:fe_users.use_gravatar',
 		'config' => [
 			'type' => 'check',
 		],
 	],
 	'tx_typo3forum_contact' => [
+		'exclude' => 1,
 		'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:fe_users.contact',
 		'config' => [
 			'type' => 'none',


### PR DESCRIPTION
The three columns rank, use_gravatar and contact were not defined as
exclude=1 in TCA of fe_users leading to admins not having the
possibility to deny access to those. This patch adds the exclude
definitions for those columns.