### PR TITLE
[BUGFIX] Remove character set definitions for cache tables

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -737,7 +737,7 @@ CREATE TABLE tx_typo3forum_cache (
   lifetime int(11) unsigned default '0',
   PRIMARY KEY (id),
   KEY cache_id (identifier)
-) ENGINE=InnoDB CHARACTER SET=utf8;
+) ENGINE=InnoDB;
 
 
 #
@@ -750,4 +750,4 @@ CREATE TABLE tx_typo3forum_cache_tags (
   PRIMARY KEY (id),
   KEY cache_id (identifier),
   KEY cache_tag (tag)
-) ENGINE=InnoDB CHARACTER SET=utf8;
+) ENGINE=InnoDB;


### PR DESCRIPTION
A separate definition setting the character set for the cache tables is
not needed in any current version of TYPO3 as UTF-8 always is default.
In contrast it causes issues with databases configured to use `utf8mb4`.
In order to simply use the database default as all other tables do this
patch removes the character set definitions for the cache tables.

Fixes: #333 