### PR TITLE
[BUGFIX] Send link to forum instead of topic in new topic notification

### DIFF
--- a/Classes/Service/Notification/NotificationService.php
+++ b/Classes/Service/Notification/NotificationService.php
@@ -148,6 +148,8 @@ class NotificationService extends AbstractService implements NotificationService
 		$marker = [
 			'###POST_AUTHOR###' => $post->getAuthor()->getUsername(),
 			'###FORUM_NAME###' => $forum->getTitle(),
+			'###FORUM_LINK###' => $this->getForumLink($topic->getForum()),
+			'###TOPIC_NAME###' => $topic->getName(),
 			'###TOPIC_LINK###' => $this->getTopicLink($forum, $topic),
 			'###UNSUBSCRIBE_LINK###' => $unsubscribeLink,
 			'###FORUM_TEAM###' => $this->settings['mailing']['sender']['name']
@@ -158,6 +160,23 @@ class NotificationService extends AbstractService implements NotificationService
 		}
 
 		return $message;
+	}
+
+	protected function getForumLink(Forum $forum) {
+		$arguments = [
+			'tx_typo3forum_pi1[controller]' => 'Forum',
+			'tx_typo3forum_pi1[action]' => 'show',
+			'tx_typo3forum_pi1[forum]' => $forum->getUid(),
+		];
+
+		$forumLink = $this->uriBuilder
+			->setTargetPageUid($this->settings['pids']['Forum'])
+			->setArguments($arguments)
+			->setCreateAbsoluteUri(TRUE)
+			->build();
+		$this->uriBuilder->reset();
+
+		return '<a href="' . $forumLink . '">"' . $forum->getTitle() . '"</a>';
 	}
 
 	protected function getTopicLink(Forum $forum, Topic $topic) {

--- a/Resources/Private/Language/locallang.xml
+++ b/Resources/Private/Language/locallang.xml
@@ -932,7 +932,7 @@ Dein ###FORUM_TEAM###-Team</label>
 			<label index="Mail_Subscribe_NewTopic_Subject">Neues Thema in einem von Dir abonnierten Forum!</label>
 			<label index="Mail_Subscribe_NewTopic_Body">Hallo ###RECIPIENT###,
 
-###POST_AUTHOR### hat das Thema ###TOPIC_LINK### in dem von dir abonnierten Forum ###FORUM_NAME### erstellt.
+###POST_AUTHOR### hat das Thema "###TOPIC_NAME###" in dem von dir abonnierten Forum ###FORUM_LINK### erstellt.
 
 Falls Du keine Benachrichtigungen zu diesem Forum mehr erhalten möchtest, kannst Du diese im Forum oder mit folgendem Link abbestellen: ###UNSUBSCRIBE_LINK###
 


### PR DESCRIPTION
When the 'onTopicCreated' signal is sent the new topic has not been
persisted yet. This leads to current notifications for new topics being
sent with an invalid link (as it does not contain a topic uid)

Changing this would change the signal for other extensions using the
signal. Instead of doing so this patch makes the notification for a new
topic behave like one for a new post: Send a link to the parent object
(here the forum) and the name of the object (here the topic) instead.